### PR TITLE
#8 issue finding compile dependencies with gradle 1.11

### DIFF
--- a/robospock-plugin/src/main/groovy/org/robospock/RobospockAction.groovy
+++ b/robospock-plugin/src/main/groovy/org/robospock/RobospockAction.groovy
@@ -80,15 +80,9 @@ class RobospockAction implements Action<Project> {
     }
 
     def findCompileDependencies(Project androidProject) {
-        def androidProjectDependenciesList = new ArrayList()
-
-        androidProject.dependencies.each {
-            androidProjectDependenciesList = it.configurationContainer.all.find {
-                it.name == 'compile'
-            }.getAllDependencies()
-        }
-
-        return androidProjectDependenciesList
+        androidProject.configurations.all.find {
+            it.name == 'compile'
+        }.getAllDependencies()
     }
 
     def findMavenDependencies(Project androidProject) {


### PR DESCRIPTION
Tested with both gradle 1.11 and 1.10 by changing the gradle version in gradle-wrapper.properties

```
./gradlew clean :robospock-plugin:test -i
```
